### PR TITLE
WebSocket for pending rating notifications.

### DIFF
--- a/app/channels/pending_rating_channel.rb
+++ b/app/channels/pending_rating_channel.rb
@@ -1,0 +1,5 @@
+class PendingRatingChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "pending_rating_#{current_user.id}"
+  end
+end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -90,6 +90,7 @@ class Api::V1::OrdersController < ApplicationController
     when 'finished'
       @order.finish!
       @volunteer.notifications.create!(title: 'Finalizado', body: "El pedido #{@title} ha sido finalizado")
+      ActionCable.server.broadcast "pending_rating_#{@volunteer.id}", order_id: @order.id
     when 'cancelled'
       @order.cancel!
       @helpee.notifications.create!(title: 'Cancelado', body: "El pedido #{@title} ha sido cancelado")


### PR DESCRIPTION
Agrega web socket para notificar de una nueva calificación pendiente en tiempo real, permitiendo bloquear la UI del usuario sin tener que esperar al próximo inicio de sesión.