### PR TITLE
Endpoint for unseen notifications.

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -2,11 +2,17 @@ class Api::V1::NotificationsController < ApplicationController
   PAGE_SIZE = 50
 
   before_action :authenticate_user!
-  before_action :index_settings, only: [:index]
+  before_action :index_settings, only: %i[index index_not_seen]
   before_action :load_notification, only: [:seen]
 
   def index
     @notifications = Notification.where(user_id: @user_id).order(id: :desc)
+                                 .limit(@page_size).offset(@offset)
+  end
+
+  def index_not_seen
+    @notifications = Notification.where(user_id: @user_id, status: :not_seen)
+                                 .order(id: :desc)
                                  .limit(@page_size).offset(@offset)
   end
 

--- a/app/views/api/v1/notifications/index_not_seen.json.jbuilder
+++ b/app/views/api/v1/notifications/index_not_seen.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+json.user_id @user_id
+json.page @page
+json.page_size @page_size
+json.notifications do
+  json.array! @notifications, partial: 'api/v1/notifications/notification', as: :notification
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
         post '/orders/status', to: 'orders#update_status'
         resources :notifications, only: %i[index]
         post '/notifications/seen', to: 'notifications#seen'
+        get '/notifications/index_not_seen', to: 'notifications#index_not_seen'
         post '/helpees/ratingPending', to: 'helpees#rating_pending'
         post '/helpees/rating', to: 'helpees#rating'
         post '/volunteers/ratingPending', to: 'volunteers#rating_pending'


### PR DESCRIPTION
Agrega _endpoint_ para recibir únicamente las notificaciones no leídas (el que había las traía todas), con paginado incluído.